### PR TITLE
handling the case of 2.16 failing

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -80,8 +80,13 @@ const appRouter = function (app, gulp) {
       console.log('Saving to cache');
       fs.readdir(directory, (err, files) => {
         files.forEach(file => {
-          if (file.startsWith(prebidPrefix)){
-            prebidVersions.push(file.replace(prebidPrefix, ''));
+          if (file.startsWith("prebid_")){   // validate filename
+            var f=file.replace("prebid_", '');
+            var v=f.split(".");
+	    // consider it valid only if there are 3 fields
+            if (v.length==3) {
+                prebidVersions.push(file.replace("prebid_", ''));
+            }
           }
         });
         prebidVersions = semverSort.desc(prebidVersions);

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -80,12 +80,12 @@ const appRouter = function (app, gulp) {
       console.log('Saving to cache');
       fs.readdir(directory, (err, files) => {
         files.forEach(file => {
-          if (file.startsWith("prebid_")){   // validate filename
-            var f=file.replace("prebid_", '');
+          if (file.startsWith(prebidPrefix)){   // validate filename
+            var f=file.replace(prebidPrefix, '');
             var v=f.split(".");
 	    // consider it valid only if there are 3 fields
             if (v.length==3) {
-                prebidVersions.push(file.replace("prebid_", ''));
+                prebidVersions.push(file.replace(prebidPrefix, ''));
             }
           }
         });


### PR DESCRIPTION
this is failing every morning because prebid_2.16 is refreshed, causing the sort to fail. Just skipping any entry that doesn't have the pattern `prebid_STRING.STRING.STRING`