### PR TITLE
Add a way to remove bundles and versions

### DIFF
--- a/buildCleanup.sh
+++ b/buildCleanup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+NUMBER_OF_LATEST_VERSIONS="&1"
+
+if [ $NUMBER_OF_LATEST_VERSIONS -gt 0 ]; then
+  echo "deleting prebid files older than last $NUMBER_OF_LATEST_VERSIONS versions"
+else
+  NUMBER_OF_LATEST_VERSIONS=1
+  echo "deleting prebid files older than last $NUMBER_OF_LATEST_VERSIONS versions"
+fi
+
+cd prebid.js
+
+LATEST_VERSION=0
+for DIR in prebid_*;
+  do
+    VERSION_SUBSTRING=$(echo $DIR | cut -c8-11)
+    VERSION=$(echo $VERSION_SUBSTRING | tr -d .)
+      if [ $VERSION -gt $LATEST_VERSION ]; then
+        LATEST_VERSION=$VERSION
+      fi
+  done
+
+LAST_SUPPORTED_VERSION=$(($LATEST_VERSION-$NUMBER_OF_LATEST_VERSIONS+1))
+for DIR in prebid_*;
+  do
+    VERSION_SUBSTRING=$(echo $DIR | cut -c8-11)
+    VERSION=$(echo $VERSION_SUBSTRING | tr -d .)
+      if [ $VERSION -lt $LAST_SUPPORTED_VERSION ]; then
+        echo "deleting directory $DIR"
+        rm -rf $DIR
+      fi
+  done
+
+echo "Versions clean up complete"

--- a/buildCleanup.sh
+++ b/buildCleanup.sh
@@ -1,35 +1,27 @@
 #!/bin/bash
 
-NUMBER_OF_LATEST_VERSIONS="&1"
+NUMBER_OF_LATEST_VERSIONS="$1"
 
 if [ $NUMBER_OF_LATEST_VERSIONS -gt 0 ]; then
   echo "deleting prebid files older than last $NUMBER_OF_LATEST_VERSIONS versions"
 else
-  NUMBER_OF_LATEST_VERSIONS=1
+  NUMBER_OF_LATEST_VERSIONS=20
   echo "deleting prebid files older than last $NUMBER_OF_LATEST_VERSIONS versions"
 fi
 
 cd prebid.js
 
-LATEST_VERSION=0
-for DIR in prebid_*;
-  do
-    VERSION_SUBSTRING=$(echo $DIR | cut -c8-11)
-    VERSION=$(echo $VERSION_SUBSTRING | tr -d .)
-      if [ $VERSION -gt $LATEST_VERSION ]; then
-        LATEST_VERSION=$VERSION
-      fi
-  done
+VERSION_DIRECTORIES="$(ls -d prebid_* | sort -r)"
 
-LAST_SUPPORTED_VERSION=$(($LATEST_VERSION-$NUMBER_OF_LATEST_VERSIONS+1))
-for DIR in prebid_*;
+ITERATION=0
+for DIR in $VERSION_DIRECTORIES;
   do
-    VERSION_SUBSTRING=$(echo $DIR | cut -c8-11)
-    VERSION=$(echo $VERSION_SUBSTRING | tr -d .)
-      if [ $VERSION -lt $LAST_SUPPORTED_VERSION ]; then
-        echo "deleting directory $DIR"
-        rm -rf $DIR
-      fi
+    if [ $ITERATION -lt $NUMBER_OF_LATEST_VERSIONS ]; then
+      ITERATION=$[ITERATION+1]
+      continue
+    fi
+  echo "deleting directory $DIR"
+  rm -rf $DIR
   done
 
 echo "Versions clean up complete"

--- a/bundleCleanup.sh
+++ b/bundleCleanup.sh
@@ -14,7 +14,7 @@ CURRENT_TIME=$(date +%s)
 for DIR in prebid.js/prebid_*;
   do
     echo "checking $DIR"
-    BUNDLE_DIR="${DIR}/build/dist/*"
+    BUNDLE_DIR="${DIR}/build/dist/prebid.*.js"
     for FILE in $BUNDLE_DIR;
       do
       FILE_LAST_MODIFIED=$(stat -c%Y $FILE)

--- a/bundleCleanup.sh
+++ b/bundleCleanup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+BUNDLE_LIFE_PERIOD="$1"
+
+if [ $BUNDLE_LIFE_PERIOD -gt 0 ]; then
+  echo "deleting bundles older than $BUNDLE_LIFE_PERIOD seconds"
+else
+  BUNDLE_LIFE_PERIOD=300
+  echo "deleting bundles older than $BUNDLE_LIFE_PERIOD seconds"
+fi
+
+CURRENT_TIME=$(date +%s)
+
+for DIR in prebid.js/prebid_*;
+  do
+    echo "checking $DIR"
+    BUNDLE_DIR="${DIR}/build/dist/*"
+    for FILE in $BUNDLE_DIR;
+      do
+      FILE_LAST_MODIFIED=$(stat -c%Y $FILE)
+        if [ "$(($CURRENT_TIME-$FILE_LAST_MODIFIED))" -gt $BUNDLE_LIFE_PERIOD ]; then
+        echo "deleting file $FILE"
+        rm -f $FILE
+        fi
+      done
+    done
+
+echo "Bundles clean up complete"

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -44,7 +44,13 @@ const appRouter = function (app, gulp) {
       const prebidDownloadFilePath = path.resolve(prebidPath, 'build/dist', fileName);
       console.log(output);
       if(fs.existsSync(prebidDownloadFilePath)) {
-        res.download(prebidDownloadFilePath);
+        res.download(prebidDownloadFilePath, function (err) {
+          if (err) {
+            res.end();
+          } else {
+            fs.unlinkSync(prebidDownloadFilePath);
+          }
+        });
       }
       else {
         res.send(JSON.stringify({

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -37,7 +37,7 @@ const appRouter = function (app, gulp) {
     // for logging CSV
     logModules = modulesListStr.replace(/,/g, ';');
     logInfo(req.body.version, logModules);
-   
+
     // generate file from command line
     // gulp bundle --modules ${module_list} --bundleName prebid.${uuid}.js
     runCmd.runCmd('gulp', ['--cwd', prebidPath, 'bundle', '--modules', modulesListStr, '--bundleName', fileName], function(output) {
@@ -48,7 +48,9 @@ const appRouter = function (app, gulp) {
           if (err) {
             res.end();
           } else {
-            fs.unlinkSync(prebidDownloadFilePath);
+            fs.unlink(prebidDownloadFilePath, function (err) {
+              if (err) return console.log(err);
+            });
           }
         });
       }
@@ -59,7 +61,7 @@ const appRouter = function (app, gulp) {
           }
         ));
       }
-      
+
     })
   });
 
@@ -109,7 +111,7 @@ const appRouter = function (app, gulp) {
 
   /**
    * WIP: get a list of modules supported by a given version.
-   * TODO: needs to support aliases. 
+   * TODO: needs to support aliases.
    */
   app.get('/bidders', function (req, res) {
 
@@ -137,7 +139,7 @@ const appRouter = function (app, gulp) {
     const analytics = [];
     const modules = [];
     const directory = `prebid.js/prebid_${req.query.id}/modules/`;
-    
+
     fs.readdir(directory, (err, files) => {
       if(err) {
         res.send(JSON.stringify({error : 'invalid version specified'}));
@@ -166,8 +168,8 @@ const appRouter = function (app, gulp) {
 
       res.send(JSON.stringify(response));
     })
-    
-  
+
+
   });
 
   function isValidRequest(req, res) {


### PR DESCRIPTION
Added a callback to POST `/download` endpoint that would remove bundle after download was successfully completed;
Added script to remove any bundles that are older than `x` amount of seconds (default 300 i.e. 5 minutes) ;
Added script to remove files of versions older then `x` latest versions, default - older than last 10 versions.