### PR TITLE
Upgrade node to v12; separate images for dev and prod

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,9 +1,9 @@
-FROM node:10-alpine AS build
+FROM node:12-alpine AS build
 
 COPY package*.json ./
 RUN npm install --production
 
-FROM node:10-alpine
+FROM node:12-alpine
 
 RUN npm install -g gulp gulp-cli
 

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 RUN npm install -g gulp gulp-cli
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-set -x
+TAG="$1"
 
-docker build -t prebid/pbjs-bundle-service-api:latest -f docker/Dockerfile.api .
-docker build -t prebid/pbjs-bundle-service-builder:latest -f docker/Dockerfile.builder .
+if [ -z "$TAG" ]; then
+  TAG="latest"
+fi
+
+set -x
+docker build -t prebid/pbjs-bundle-service-api:"$TAG" -f docker/Dockerfile.api .
+docker build -t prebid/pbjs-bundle-service-builder:"$TAG" -f docker/Dockerfile.builder .

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,8 +86,8 @@ Scaling service down involves following actions in AWS Console:
 
 ## Application redeployment
 
-To keep things simple there will be only one tag for images - `latest`, i.e. no versioning support.
+To keep things simple there will be only one tag for images - `latest` for prod, `dev` for dev, i.e. no versioning support.
 
 In order to update the application:
-1. Build the new version of the Docker images, tag them with `latest` tag and push to the ECR repositories
+1. Build the new version of the Docker images, tag them with `latest` (or `dev`) tag and push to the ECR repositories
 2. Stop ECS Tasks one by one - ECS will start a new Task instead of each stopped one that will cause new images to be pulled

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -11,7 +11,15 @@ Alternatively you can use a helper script for this purpose (should be run from t
 docker/build.sh
 ```
 
-This will build the images locally and tag them as `latest`.
+This will build the images locally and tag them as `latest`. To use a different tag, run:
+```shell script
+docker/build.sh <TAG>
+```
+
+Note that:
+
+- The "dev" stack (ECS cluster "prebid-network-dev-ecs-cluster") is configured to use the "dev" tag;
+- The "prod" stack (ECS cluster "prebid-network-prod-ecs-cluster") is configured to use the "latest" tag.
 
 ## Docker images description
 [Builder](../docker/Dockerfile.builder) image has cron installed and crontab configured to run: 


### PR DESCRIPTION
Update Docker image bases to use node v12﻿.

Also, I modified the existing "dev" stack to use the "dev" Docker tag (to separate it from prod). These changes have been deployed there, this is an example request hitting it:

```shell
curl -X POST https://js-download-dev.prebid.org/download -d "modules=prebidServerBidAdapter&modules=rubiconBidAdapter&version=6.12.0"
```

The plan is to leave it running on v12 through a release and make sure it does not break, then tag them with "latest" and restart the prod cluster.


