### PR TITLE
Upgrade ec2 instance type to t2.medium; give more memory to builder container

### DIFF
--- a/cloudformation/service.yaml
+++ b/cloudformation/service.yaml
@@ -14,7 +14,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.micro
+    Default: t2.medium
     AllowedValues: [t2.micro, t2.small, t2.medium, t2.large, m3.medium, m3.large,
       m3.xlarge, m3.2xlarge, m4.large, m4.xlarge, m4.2xlarge, m4.4xlarge, m4.10xlarge,
       c4.large, c4.xlarge, c4.2xlarge, c4.4xlarge, c4.8xlarge, c3.large, c3.xlarge,
@@ -50,35 +50,9 @@ Parameters:
     Type: Number
     Default: 3000
     Description: What port number the application inside the docker container is binding to
-  TaskCpu:
-    Type: Number
-    Default: 1024
-    AllowedValues:
-      - 256
-      - 512
-      - 1024
-      - 2048
-      - 4096
-    Description: How much CPU to give the task. 1024 is 1 CPU
-  TaskMemory:
-    Type: Number
-    Default: 980
-    AllowedValues:
-      - 512
-      - 980
-      - 1024
-      - 2048
-      - 3072
-      - 4096
-      - 5120
-      - 6144
-      - 7168
-      - 8192
-      - 16384
-    Description: How much memory in megabytes to give the task
   ApiContainerCpu:
     Type: Number
-    Default: 512
+    Default: 1024
     AllowedValues:
       - 256
       - 512
@@ -88,7 +62,7 @@ Parameters:
     Description: How much CPU to give the container. 1024 is 1 CPU
   BuilderContainerCpu:
     Type: Number
-    Default: 512
+    Default: 1024
     AllowedValues:
       - 256
       - 512
@@ -113,7 +87,7 @@ Parameters:
     Description: How much memory in megabytes to give the container
   BuilderContainerMemory:
     Type: Number
-    Default: 512
+    Default: 3072
     AllowedValues:
       - 512
       - 1024
@@ -149,7 +123,7 @@ Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      LaunchConfigurationName: !Join ['-', [!Ref 'AWS::StackName', 'lc']]
+      LaunchConfigurationName: !Join ['-', [!Ref 'AWS::StackName', 'lc2']]
       ImageId: !Ref ECSAMI
       KeyName: !Ref KeyName
       InstanceType: !Ref InstanceType
@@ -292,8 +266,6 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: !Join ['-', [!Ref 'AWS::StackName', 'task-def']]
-      Cpu: !Ref 'TaskCpu'
-      Memory: !Ref 'TaskMemory'
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -91,3 +91,7 @@ To keep things simple there will be only one tag for images - `latest` for prod,
 In order to update the application:
 1. Build the new version of the Docker images, tag them with `latest` (or `dev`) tag and push to the ECR repositories
 2. Stop ECS Tasks one by one - ECS will start a new Task instead of each stopped one that will cause new images to be pulled
+
+**Note**: ECS service deployments will not complete if they run on only one task (as they cannot be done safely). 
+To redeploy to a single host, or to replace the host (for example when moving to a bigger instance type), it's necessary 
+to update both the ECS task definition's and the ASG's desired count to 0 - to take the old host out of service - then back to 1.


### PR DESCRIPTION
Increase size of builder hosts to accomodate increased memory requirements for v6.17

This is deployed to the "dev"﻿ stack; to test:

```
curl -X POST https://js-download-dev.prebid.org/download -d "modules=prebidServerBidAdapter&modules=rubiconBidAdapter&version=6.17.0"
```

